### PR TITLE
fix #24 ICMP ping field Sequence Number does not fit in size

### DIFF
--- a/src/model/generators/protocols/icmp_echo_payload_generator.cpp
+++ b/src/model/generators/protocols/icmp_echo_payload_generator.cpp
@@ -43,7 +43,7 @@ namespace hyenae::model::generators::protocols
         _packet.add_generator(_id);
 
         // Sequence Number
-        _seq_num = integer_generator::create_uint32(
+        _seq_num = integer_generator::create_uint16(
             seq_num_pattern, seq_num_pattern_base);
         _seq_num->add_transformation(to_network_order_t::get_instance());
         _packet.add_generator(_seq_num);


### PR DESCRIPTION
Sequence Number would be 16 bits.